### PR TITLE
Compatibility changes for RN 0.25 and greater

### DIFF
--- a/lib/Indicator.js
+++ b/lib/Indicator.js
@@ -1,11 +1,11 @@
 'use strict'
 
 import Style from './Style'
-import React, {
+import React, {PropTypes} from 'react'
+import {
   View,
   ActivityIndicatorIOS,
-  Image,
-  PropTypes
+  Image
 } from 'react-native'
 
 export default class Indicator extends React.Component {
@@ -33,4 +33,3 @@ export default class Indicator extends React.Component {
 Indicator.propTypes = {
   needPull: PropTypes.bool
 }
-

--- a/lib/PullToRefreshViewAndroid.js
+++ b/lib/PullToRefreshViewAndroid.js
@@ -1,10 +1,7 @@
 'use strict'
 
-import React, {
-  ScrollView,
-  PullToRefreshViewAndroid,
-  PropTypes
-} from 'react-native'
+import React, { PropTypes } from 'react'
+import { PullToRefreshViewAndroid, ScrollView } from 'react-native'
 
 export default class PTRViewAndroid extends React.Component {
   constructor () {

--- a/lib/PullToRefreshViewiOS.js
+++ b/lib/PullToRefreshViewiOS.js
@@ -1,11 +1,8 @@
 'use strict'
 
 import Indicator from './Indicator'
-import React, {
-  View,
-  ScrollView,
-  PropTypes
-} from 'react-native'
+import React, { PropTypes } from 'react'
+import { View, ScrollView } from 'react-native'
 
 const INDICATOR_HEIGHT = 40
 


### PR DESCRIPTION
React API must be now required from react package (previously a warning on 0.25)
