### PR TITLE
fix "drift" caused by repeated refreshing

### DIFF
--- a/lib/PullToRefreshView.ios.js
+++ b/lib/PullToRefreshView.ios.js
@@ -54,7 +54,8 @@ export default class PTRViewiOS extends React.Component {
   _endLoading () {
     this.setState({
       isLoading: false,
-      scroll_offset: 0
+      scroll_offset: 0,
+      expand: -INDICATOR_HEIGHT
     })
     this._expander(false)
   }


### PR DESCRIPTION
after you refresh the list a few times, the first cell has a "drift" from the top --it starts to get hidden.

here we are resetting the offset to its initial value to overcome this "drift".