### PR TITLE
use onScroll function passed in component props for iOS

### DIFF
--- a/lib/PullToRefreshView.ios.js
+++ b/lib/PullToRefreshView.ios.js
@@ -23,6 +23,8 @@ export default class PTRViewiOS extends React.Component {
       this.setState({scroll_offset: offset})
       this.setState({needPull: offset > -this.props.offset})
     }
+    const { onScroll } = this.props;
+    onScroll(e);
   }
   _handleRelease (e) {
     if (this.state.scroll_offset > -this.props.offset) {


### PR DESCRIPTION
Hi, I detected that onScroll function passed in props to PTRView component wasn't called only on iOS. 
An issue related to this problem has already been opened  : https://github.com/moschan/react-native-pull-to-refresh/issues/28
This pull request fix the issue by adding the missing call.